### PR TITLE
MMTR-12 remove stun server lookup

### DIFF
--- a/client/src/js/core/stream.js
+++ b/client/src/js/core/stream.js
@@ -25,13 +25,7 @@ Stream.prototype.start = function() {
 }
 
 Stream.prototype.createPeerConnection = function() {
-    let peerConnectionConf = {
-        "iceServers": [{
-            "urls": ["stun:" + this.hostname + ":3478"]
-        }]
-    };
-
-    this.peerConnection = new window.RTCPeerConnection(peerConnectionConf);
+    this.peerConnection = new window.RTCPeerConnection(null);
 
     this.peerConnection.onicecandidate = (event) => {
         if (event.candidate) {


### PR DESCRIPTION
Removing the ice server configuration speeds up ice gathering and reduces failure rate.