### PR TITLE
MMTR-35: full-screen on-load. MMTR-30: cancel->fs

### DIFF
--- a/client/src/js/view/components/AdminModal.js
+++ b/client/src/js/view/components/AdminModal.js
@@ -5,13 +5,15 @@ const ADMIN_PINS = ["1337", "1940", "1985"];
 const MODAL_TIMEOUT = 30000; // 30 seconds
 let TIMEOUT;
 
-const onClickAdmin = ( msiAdmin, setMsiAdmin, msiAdminPending, setMsiAdminPending, setAdminTimeout ) => {
+const onClickAdmin = ( msiAdmin, setMsiAdmin, msiAdminPending, setMsiAdminPending, setAdminTimeout, toFullScreen, cancelFullScreen ) => {
   const pass = document.getElementById("password").value;
   if (pass && ADMIN_PINS.includes(pass)) {
     setMsiAdmin(!msiAdmin);
     setAdminTimeout();
   }
   setMsiAdminPending(!msiAdminPending);
+  cancelFullScreen();
+  toFullScreen();
 };
 
 const setModalTimeout = (setMsiAdminPending) => {
@@ -28,7 +30,7 @@ const resetModalTimeout = (setMsiAdminPending) => {
   setModalTimeout(setMsiAdminPending);
 };
 
-export default function AdminModal({ msiAdminPending, setMsiAdminPending, msiAdmin, setMsiAdmin, setAdminTimeout }) {
+export default function AdminModal({ msiAdminPending, setMsiAdminPending, msiAdmin, setMsiAdmin, setAdminTimeout, toFullScreen, cancelFullScreen }) {
   keyboardJS.bind("enter", function (e) {
     e.preventDefault();
     e.preventRepeat();
@@ -36,7 +38,7 @@ export default function AdminModal({ msiAdminPending, setMsiAdminPending, msiAdm
       return;
     }
 
-    onClickAdmin(msiAdmin, setMsiAdmin, msiAdminPending, setMsiAdminPending, setAdminTimeout);
+    onClickAdmin(msiAdmin, setMsiAdmin, msiAdminPending, setMsiAdminPending, setAdminTimeout, toFullScreen, cancelFullScreen);
   });
 
   return (
@@ -60,7 +62,9 @@ export default function AdminModal({ msiAdminPending, setMsiAdminPending, msiAdm
                     setMsiAdmin,
                     msiAdminPending,
                     setMsiAdminPending,
-                    setAdminTimeout
+                    setAdminTimeout,
+                    toFullScreen,
+                    cancelFullScreen
                   )
                 }
               >
@@ -71,7 +75,7 @@ export default function AdminModal({ msiAdminPending, setMsiAdminPending, msiAdm
         </div>
         <span
           className="modal--close"
-          onclick={() => setMsiAdminPending(!msiAdminPending)}
+          onclick={() => setMsiAdminPending(!msiAdminPending) && cancelFullScreen() && toFullScreen()}
           role="button"
           tabIndex={0}
         >

--- a/client/src/js/view/components/topbar.js
+++ b/client/src/js/view/components/topbar.js
@@ -1,6 +1,6 @@
 import { h } from 'hyperapp';
 
-export const TopBar = ({ msiAdmin, state, switchSettings }) =>
+export const TopBar = ({ msiAdmin, state, switchSettings, toFullScreen, cancelFullScreen }) =>
     <section id="topbar" class="topbar">
         <img alt="" class="topbar_logo" src={require('../../../img/ui/turtle-logo.svg')} />
         <div class="topbar_indicators">
@@ -8,13 +8,8 @@ export const TopBar = ({ msiAdmin, state, switchSettings }) =>
             {msiAdmin && <IndicatorSignal signalLevel={state.signalLevel} />}
         </div>
         <div id="topbar_actions" class="topbar_actions">
-            {/* <img class="topbar_actions_action" id="button-screenrecord" src={require("../../../img/ui/nav-bar-rec.svg")}/> */}
-            {/* <a id="snap-download-a">  */}
-            {/* <img class="topbar_actions_action" id="button-screenshot" src={require("../../../img/ui/nav-bar-snap.svg")}/> */}
-            {/* </a>  */}
-            { msiAdmin && <ActionFullscreen /> }
+            {msiAdmin && <ActionFullscreen toFullScreen={toFullScreen} cancelFullScreen={cancelFullScreen} />}
         </div>
-
         {
             msiAdmin &&
             <div role="button" class="topbar_menu" onmousedown={() => switchSettings()}>
@@ -58,33 +53,22 @@ const signalLevelIcon = (signalLevel) => {
     }
 };
 
-const ActionFullscreen = () =>
+const ActionFullscreen = ({ toFullScreen, cancelFullScreen }) =>
     <img
         alt=""
         class="topbar_actions_action"
         id="button-fullscreen"
         src={require('../../../img/ui/nav-bar-fullscreen.svg')}
-        onmouseup={(event) => toggleFullscreen(event)}
+        onmouseup={(event) => toggleFullscreen(event, toFullScreen, cancelFullScreen)}
     />;
 
 
 // https://gist.github.com/demonixis/5188326
-const toggleFullscreen = (event) => {
-    let element = document.body;
+const toggleFullscreen = (event, toFullScreen, cancelFullScreen) => {
+    let element = document.documentElement;
     if (event instanceof window.HTMLElement) {
         element = event;
     }
 
-    const isFullscreen = document.webkitIsFullScreen || document.mozFullScreen || false;
-
-    element.requestFullScreen = element.requestFullScreen
-        || element.webkitRequestFullScreen
-        || element.mozRequestFullScreen
-        || function a() { return false; };
-    document.cancelFullScreen = document.cancelFullScreen
-        || document.webkitCancelFullScreen
-        || document.mozCancelFullScreen
-        || function a() { return false; };
-
-    isFullscreen ? document.cancelFullScreen() : element.requestFullScreen();
+    toFullScreen(element) || cancelFullScreen();
 };

--- a/client/src/js/view/index.js
+++ b/client/src/js/view/index.js
@@ -22,8 +22,51 @@ const view = (state, actions) => {
     clearTimeout(ADMIN_TIMEOUT);
   }
 
+  const toFullScreen = (element = document.documentElement) => {
+    const isFullscreen =
+      (document.fullScreenElement && document.fullScreenElement !== null) ||
+      (document.mozFullScreen || document.webkitIsFullScreen) ||
+      false;
+
+    if (isFullscreen) {
+      return;
+    }
+
+    if (element.requestFullscreen) {
+      element.requestFullscreen();
+    } else if (element.mozRequestFullScreen) {
+      element.mozRequestFullScreen();
+    } else if (element.webkitRequestFullScreen) {
+      element.webkitRequestFullScreen();
+    }
+  };
+
+  const cancelFullScreen = () => {
+    const isFullscreen =
+      (document.fullScreenElement && document.fullScreenElement !== null) ||
+      (document.mozFullScreen || document.webkitIsFullScreen) ||
+      false;
+
+    if (!isFullscreen) {
+      return;
+    }
+
+    if (document.exitFullscreen) {
+      document.exitFullscreen();
+    } else if (document.webkitExitFullscreen) {
+      document.webkitExitFullscreen();
+    } else if (document.mozCancelFullScreen) {
+      document.mozCancelFullScreen();
+    } else if (document.msExitFullscreen) {
+      document.msExitFullscreen();
+    }
+  };
+
   return (
     <main>
+      {
+        Object.onload = toFullScreen()
+      }
       <section>
         <AdminModal
           msiAdminPending={state.msiAdminPending}
@@ -31,6 +74,8 @@ const view = (state, actions) => {
           msiAdmin={state.msiAdmin}
           setMsiAdmin={actions.setMsiAdmin}
           setAdminTimeout={setAdminTimeout}
+          toFullScreen={toFullScreen}
+          cancelFullScreen={cancelFullScreen}
         />
       </section>
       <Rotate />
@@ -47,6 +92,8 @@ const view = (state, actions) => {
           msiAdmin={state.msiAdmin}
           state={state.telemetry}
           switchSettings={actions.settings.setVisibility}
+          toFullScreen={toFullScreen}
+          cancelFullScreen={cancelFullScreen}
         />
         <section>
           {state.msiAdmin && <Settings state={state} actions={actions} />}


### PR DESCRIPTION
Full-screen on-load for MMTR-35

MMTR-30:
Cancel then fullscreen immediately on any modal click action.
This will prevent the bar from popping up, which prevents the user from hacking their way out of full-screen mode.